### PR TITLE
Fixes: Modeldump of key model including the not set fields leads to failures in PyJWT

### DIFF
--- a/fastapi_jwks/validators/jwks_validator.py
+++ b/fastapi_jwks/validators/jwks_validator.py
@@ -75,7 +75,7 @@ class JWKSValidator(Generic[DataT]):
                 if key.kid == header.kid:
                     public_key = algorithms.get_default_algorithms()[
                         header.alg
-                    ].from_jwk(key.model_dump())
+                    ].from_jwk(key.model_dump(exclude_none=True))
                     break
             if public_key is None:
                 logger.debug(


### PR DESCRIPTION
In my case the json response for the key did not contain all the fields specified in the model (e.g. `d`).

Per default the ` key.model_dump()`  includes all the None values, ie. all non set fields as well. 
PyJWT on the other hand does only check whether the dict contains the key or not and not if the value associated with the key is actually present, which leads to an error there.

By excluding the fields which are not set in the dump, everything works as intended.