### PR TITLE
chore: remove upper bound from Python version specifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1142,5 +1142,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.10"
-content-hash = "92167d2ff902527b58a43bf0f7afb077e902a8120f9bd3ca781324fba0cdd494"
+python-versions = ">=3.10"
+content-hash = "35def584d31a0b8a832dc9abf6a94ebcd99f5d096336ac7c752641d196118bde"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["bakdata"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10"
 pydantic = "^2.7.1"
 fastapi = ">=0.111.0, <1.0"
 pyjwt = { extras = ["crypto"], version = "^2.8.0" }


### PR DESCRIPTION
Thanks for creating this wonderful library, it really fills a gap in the FastAPI ecosystem! :bow:

I've noticed a few opportunities for improvement that I'd like to contribute, starting with this one:

Capping the Python version (e.g. `<4`) is a bad practice.

* https://github.com/pypa/packaging.python.org/pull/850
* https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
* https://discuss.python.org/t/requires-python-upper-limits/12663

Especially with Poetry's backtracking solver, projects in the ecosystem using Poetry are forced to upper-bound the Python version if at least one of their dependencies does so.

For this reason, I've removed the upper bound.